### PR TITLE
fix: skip phantom nested execTransaction on chains with broken trace …

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -575,6 +575,12 @@ ETH_INTERNAL_TRACE_TXS_BATCH_SIZE = env.int(
 ETH_INTERNAL_TX_DECODED_PROCESS_BATCH = env.int(
     "ETH_INTERNAL_TX_DECODED_PROCESS_BATCH", default=500
 )  # Number of InternalTxDecoded to process together. Keep it low to be memory friendly
+ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD = env.int(
+    "ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD", default=5000
+)  # Defends against chains with broken trace error reporting (e.g. Rootstock) where
+# nested execTransaction calls that reverted at signature check are reported with
+# error=None. A genuine execTransaction always consumes well above this gas; a
+# silent revert consumes ~1500. Set to 0 to disable.
 
 # Event indexing configuration (L2 and ERC20/721)
 # ------------------------------------------------------------------------------

--- a/safe_transaction_service/history/indexers/tx_processor.py
+++ b/safe_transaction_service/history/indexers/tx_processor.py
@@ -34,6 +34,7 @@ from safe_transaction_service.safe_messages import models as safe_message_models
 
 from ..models import (
     EthereumTx,
+    EthereumTxCallType,
     InternalTx,
     InternalTxDecoded,
     ModuleTransaction,
@@ -235,6 +236,44 @@ class SafeTxProcessor(TxProcessor):
         :return: Safe version for master copy address
         """
         return SafeMasterCopy.objects.get_version_for_address(master_copy)
+
+    def is_phantom_nested_exec_transaction(self, internal_tx: InternalTx) -> bool:
+        """
+        Detect a phantom nested ``execTransaction`` reverted at signature verification
+        but reported as ``error=None`` by chains with broken trace error reporting
+        (e.g. Rootstock). The Safe contract's nonce++ inside the inner call is
+        reverted along with the inner failure, so these calls cannot consume real
+        nonces — the indexer must skip them or it will burn nonces on the Safe's
+        queued transactions.
+
+        Discriminator: a genuine ``execTransaction`` always consumes well above
+        ``settings.ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD`` (nonce SSTORE
+        ~5K-22K + ECDSA recover ~3K + event emit ~2K + final call). A revert at
+        the signature check stops before any storage write and consumes ~1500
+        gas. We additionally require that this trace is nested inside another
+        ``execTransaction`` by the same Safe in the same ethereum_tx; on chains
+        with proper trace error reporting that ancestor never reaches the DB
+        (``filter_out_errored_traces`` drops it), so this guard is a no-op there.
+        """
+        from django.conf import settings
+
+        threshold = getattr(
+            settings, "ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD", 5000
+        )
+        if threshold <= 0 or internal_tx.gas_used >= threshold:
+            return False
+        parts = internal_tx.trace_address.split(",") if internal_tx.trace_address else []
+        if len(parts) < 2:
+            return False
+        prefixes = [",".join(parts[:i]) for i in range(1, len(parts))]
+        return InternalTxDecoded.objects.filter(
+            function_name="execTransaction",
+            internal_tx__ethereum_tx_id=internal_tx.ethereum_tx_id,
+            internal_tx___from=internal_tx._from,
+            internal_tx__call_type=EthereumTxCallType.DELEGATE_CALL.value,
+            internal_tx__trace_address__in=prefixes,
+            internal_tx__error=None,
+        ).exists()
 
     def get_last_safe_status_for_address(
         self, address: ChecksumAddress
@@ -728,6 +767,20 @@ class SafeTxProcessor(TxProcessor):
                     multisig_confirmation.ethereum_tx = ethereum_tx
                     multisig_confirmation.save(update_fields=["ethereum_tx"])
             elif function_name == "execTransaction":
+                if self.is_phantom_nested_exec_transaction(internal_tx):
+                    logger.warning(
+                        "[%s] Skipping phantom nested execTransaction at trace=%s "
+                        "in tx=%s (gas_used=%d): inner revert reported as success "
+                        "by trace-buggy chain",
+                        contract_address,
+                        internal_tx.trace_address,
+                        to_0x_hex_str(HexBytes(internal_tx.ethereum_tx_id)),
+                        internal_tx.gas_used,
+                    )
+                    InternalTx.objects.filter(pk=internal_tx.pk).update(
+                        error="false_match_skipped"
+                    )
+                    return True
                 logger.debug("[%s] Processing transaction execution", contract_address)
                 # Events for L2 Safes store information about nonce
                 nonce = (

--- a/safe_transaction_service/history/tests/test_tx_processor.py
+++ b/safe_transaction_service/history/tests/test_tx_processor.py
@@ -24,6 +24,8 @@ from ..indexers.tx_processor import (
     SafeTxProcessorProvider,
 )
 from ..models import (
+    EthereumTxCallType,
+    InternalTx,
     InternalTxDecoded,
     ModuleTransaction,
     MultisigConfirmation,
@@ -646,3 +648,115 @@ class TestSafeTxProcessor(SafeTestCaseMixin, TestCase):
         safe_last_status_db = SafeLastStatus.objects.get()
         self.assertEqual(safe_last_status_db.address, safe_address)
         self.assertEqual(safe_last_status_db.nonce, 1)
+
+    def test_phantom_nested_exec_transaction_is_skipped(self):
+        """
+        Reproduce the Rootstock trace bug: an execTransaction recursively
+        delegate-calls back into the same Safe; the inner call reverts at
+        signature verification but the trace reports error=None. The processor
+        must skip such phantom calls so they don't burn nonces on queued
+        transactions.
+        """
+        tx_processor = self.tx_processor
+        owner = Account.create().address
+        safe_address = Account.create().address
+        master_copy = Account.create().address
+        tx_processor.process_decoded_transaction(
+            InternalTxDecodedFactory(
+                function_name="setup",
+                owner=owner,
+                threshold=1,
+                internal_tx__to=master_copy,
+                internal_tx___from=safe_address,
+                internal_tx__value=0,
+            )
+        )
+        self.assertEqual(SafeLastStatus.objects.get(address=safe_address).nonce, 0)
+
+        outer = InternalTxDecodedFactory(
+            function_name="execTransaction",
+            internal_tx___from=safe_address,
+            internal_tx__to=master_copy,
+            internal_tx__value=0,
+            internal_tx__trace_address="0",
+            internal_tx__call_type=EthereumTxCallType.DELEGATE_CALL.value,
+            internal_tx__gas_used=100_000,
+            internal_tx__error=None,
+        )
+        ethereum_tx = outer.internal_tx.ethereum_tx
+        spurious_traces = ["0,0,0,1,1,5,0", "0,0,0,3,1,5,0", "0,0,0,5,1,5,0"]
+        spurious = [
+            InternalTxDecodedFactory(
+                function_name="execTransaction",
+                internal_tx__ethereum_tx=ethereum_tx,
+                internal_tx___from=safe_address,
+                internal_tx__to=master_copy,
+                internal_tx__value=0,
+                internal_tx__trace_address=trace,
+                internal_tx__call_type=EthereumTxCallType.DELEGATE_CALL.value,
+                internal_tx__gas_used=1504,
+                internal_tx__error=None,
+            )
+            for trace in spurious_traces
+        ]
+
+        tx_processor.process_decoded_transactions([outer, *spurious])
+
+        # Only the outer call consumed a nonce
+        self.assertEqual(SafeLastStatus.objects.get(address=safe_address).nonce, 1)
+        # Only one MultisigTransaction was created
+        self.assertEqual(MultisigTransaction.objects.filter(safe=safe_address).count(), 1)
+        # Spurious InternalTx rows are flagged so a future reindex won't redecode
+        for s in spurious:
+            self.assertEqual(
+                InternalTx.objects.get(pk=s.internal_tx_id).error,
+                "false_match_skipped",
+            )
+        # Outer trace untouched
+        self.assertIsNone(InternalTx.objects.get(pk=outer.internal_tx_id).error)
+
+    def test_phantom_guard_disabled_when_threshold_zero(self):
+        """
+        When `ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD=0` the guard is a no-op
+        and the legacy (buggy) behaviour is preserved.
+        """
+        from django.test import override_settings
+
+        tx_processor = self.tx_processor
+        owner = Account.create().address
+        safe_address = Account.create().address
+        master_copy = Account.create().address
+        tx_processor.process_decoded_transaction(
+            InternalTxDecodedFactory(
+                function_name="setup",
+                owner=owner,
+                threshold=1,
+                internal_tx__to=master_copy,
+                internal_tx___from=safe_address,
+                internal_tx__value=0,
+            )
+        )
+        outer = InternalTxDecodedFactory(
+            function_name="execTransaction",
+            internal_tx___from=safe_address,
+            internal_tx__to=master_copy,
+            internal_tx__value=0,
+            internal_tx__trace_address="0",
+            internal_tx__call_type=EthereumTxCallType.DELEGATE_CALL.value,
+            internal_tx__gas_used=100_000,
+        )
+        ethereum_tx = outer.internal_tx.ethereum_tx
+        nested = InternalTxDecodedFactory(
+            function_name="execTransaction",
+            internal_tx__ethereum_tx=ethereum_tx,
+            internal_tx___from=safe_address,
+            internal_tx__to=master_copy,
+            internal_tx__value=0,
+            internal_tx__trace_address="0,0,0,1,1,5,0",
+            internal_tx__call_type=EthereumTxCallType.DELEGATE_CALL.value,
+            internal_tx__gas_used=1504,
+        )
+        with override_settings(ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD=0):
+            tx_processor.process_decoded_transactions([outer, nested])
+        # Without the guard the spurious row consumes a nonce (legacy bug)
+        self.assertEqual(SafeLastStatus.objects.get(address=safe_address).nonce, 2)


### PR DESCRIPTION
…error reporting

On Rootstock the trace_block RPC reports `error=None` for inner `execTransaction` calls that actually reverted at signature verification. The indexer would decode them as successful, bump the Safe nonce, and false-match against queued transactions, overwriting their `ethereum_tx_id` and signatures.

Add a guard in `SafeTxProcessor` that skips an `execTransaction` decoded internal_tx when (a) `gas_used` is below
`ETH_INTERNAL_PHANTOM_EXEC_TX_GAS_THRESHOLD` (default 5000 — a real execTransaction consumes well above this; a signature-revert consumes ~1500) and (b) it has a strict-prefix-ancestor `execTransaction` delegate-call from the same Safe in the same ethereum_tx. The skipped trace's `InternalTx.error` is set to `false_match_skipped` so a future block reindex won't redecode it.

On chains with proper trace error reporting the spurious traces are already removed by `filter_out_errored_traces`, so this guard is a no-op there.

### Make sure these boxes are checked! 📦✅

- [ ] You ran `./run_tests.sh`
- [ ] You ran `pre-commit run -a`
- [ ] If you want to add your network to `setup_service.py`, provide a link to your
    [safe-deployments PR](https://github.com/safe-global/safe-deployments/pulls) and check network name
    exists in [safe-eth-py](https://github.com/safe-global/safe-eth-py/blob/master/gnosis/eth/ethereum_network.py)

### What was wrong? 👾

Closes #

### How was it fixed? 🎯
